### PR TITLE
merge PR#14, add support for protobuf, format on save now works and etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 ## Release history
 
-### CURRENT
+### DEVELOPING
 * add protobuf support(work with https://marketplace.visualstudio.com/items?itemName=peterj.proto)
 * add javascript/typescript support
 * allow different style & fallback style option for different languages
+* format on save is available now(just like https://github.com/Microsoft/vscode-go/blob/master/src/goMain.ts)
 
 ### v 0.6.1
 * clean up dependencies #9

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 ## Release history
 
+### CURRENT
+* add protobuf support(work with https://marketplace.visualstudio.com/items?itemName=peterj.proto)
+* add javascript/typescript support
+* allow different style & fallback style option for different languages
+
 ### v 0.6.1
 * clean up dependencies #9
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "onLanguage:objective-c",
         "onLanguage:java",
         "onLanguage:javascript",
-        "onLanguage:typescript"
+        "onLanguage:typescript",
+        "onLanguage:proto"
     ],
     "contributes": {
         "configuration": {
@@ -37,15 +38,88 @@
 					"default": "clang-format",
 					"description": "clang-format executable path"
 				},
+                // style
                 "clang-format.style": {
 					"type": "string",
 					"default": "file",
 					"description": "clang-format style.(-style=value, value can be file, LLVM, Google, Chromium, Mozilla, WebKit or json configure)"
 				},
+                // fallback style
                 "clang-format.fallbackStyle": {
 					"type": "string",
 					"default": "LLVM",
 					"description": "clang-format fallback style.(-fallback-style=value, value can be none, LLVM, Google, Chromium, Mozilla, WebKit)"
+				},
+                // every language can has it's own style & fallback style option, if not confirured, use the default value above
+                "clang-format.language.cpp.style": {
+					"type": "string",
+					"default": "",
+					"description": "clang-format fallback style for c++, left empty to use clang-format.style"
+				},
+                "clang-format.language.cpp.fallbackStyle": {
+					"type": "string",
+					"default": "",
+					"description": "clang-format fallback style for c++, left empty to use clang-format.fallbackStyle"
+				},
+                "clang-format.language.c.style": {
+					"type": "string",
+					"default": "",
+					"description": "clang-format fallback style for c, left empty to use clang-format.style"
+				},
+                "clang-format.language.c.fallbackStyle": {
+					"type": "string",
+					"default": "",
+					"description": "clang-format fallback style for c, left empty to use clang-format.fallbackStyle"
+				},
+                "clang-format.language.objective-c.style": {
+					"type": "string",
+					"default": "",
+					"description": "clang-format fallback style for objective-c, left empty to use clang-format.style"
+				},
+                "clang-format.language.objective-c.fallbackStyle": {
+					"type": "string",
+					"default": "",
+					"description": "clang-format fallback style for objective-c, left empty to use clang-format.fallbackStyle"
+				},
+                "clang-format.language.java.style": {
+					"type": "string",
+					"default": "",
+					"description": "clang-format fallback style for java, left empty to use clang-format.style"
+				},
+                "clang-format.language.java.fallbackStyle": {
+					"type": "string",
+					"default": "",
+					"description": "clang-format fallback style for java, left empty to use clang-format.fallbackStyle"
+				},
+                "clang-format.language.javascript.style": {
+					"type": "string",
+					"default": "",
+					"description": "clang-format fallback style for javascript, left empty to use clang-format.style"
+				},
+                "clang-format.language.javascript.fallbackStyle": {
+					"type": "string",
+					"default": "",
+					"description": "clang-format fallback style for javascript, left empty to use clang-format.fallbackStyle"
+				},
+                "clang-format.language.typescript.style": {
+					"type": "string",
+					"default": "",
+					"description": "clang-format fallback style for typescript, left empty to use clang-format.style"
+				},
+                "clang-format.language.typescript.fallbackStyle": {
+					"type": "string",
+					"default": "",
+					"description": "clang-format fallback style for typescript, left empty to use clang-format.fallbackStyle"
+				},
+                "clang-format.language.proto.style": {
+					"type": "string",
+					"default": "",
+					"description": "clang-format fallback style for proto, left empty to use clang-format.style"
+				},
+                "clang-format.language.proto.fallbackStyle": {
+					"type": "string",
+					"default": "",
+					"description": "clang-format fallback style for proto, left empty to use clang-format.fallbackStyle"
 				}
             }
         }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
         "onLanguage:cpp",
         "onLanguage:c",
         "onLanguage:objective-c",
-        "onLanguage:java"
+        "onLanguage:java",
+        "onLanguage:javascript",
+        "onLanguage:typescript"
     ],
     "contributes": {
         "configuration": {

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "devDependencies": {
-        "typescript": "^1.6.2",
-        "vscode": "0.10.x"
+        "typescript": "^1.8.5",
+        "vscode": "^0.11.0"
     },
     "icon": "clang-format.png",
     "repository": {

--- a/src/clangMode.ts
+++ b/src/clangMode.ts
@@ -2,5 +2,5 @@
 
 import vscode = require('vscode');
 
-const LANGUAGES: string[] = ['cpp', 'c', 'objective-c', 'java'];
+const LANGUAGES: string[] = ['cpp', 'c', 'objective-c', 'java', 'javascript', 'typescript'];
 export const MODES: vscode.DocumentFilter[] = LANGUAGES.map(language => ({ language, scheme: 'file' }));

--- a/src/clangMode.ts
+++ b/src/clangMode.ts
@@ -2,7 +2,5 @@
 
 import vscode = require('vscode');
 
-export const CPP_MODE: vscode.DocumentFilter = { language: 'cpp', scheme: 'file' }
-export const C_MODE: vscode.DocumentFilter = { language: 'c', scheme: 'file' }
-export const OBJECTIVE_C_MODE: vscode.DocumentFilter = { language: 'objective-c', scheme: 'file' }
-export const JAVA_MODE: vscode.DocumentFilter = { language: 'java', scheme: 'file' }
+const LANGUAGES: string[] = ['cpp', 'c', 'objective-c', 'java'];
+export const MODES: vscode.DocumentFilter[] = LANGUAGES.map(language => ({ language, scheme: 'file' }));

--- a/src/clangMode.ts
+++ b/src/clangMode.ts
@@ -2,5 +2,5 @@
 
 import vscode = require('vscode');
 
-const LANGUAGES: string[] = ['cpp', 'c', 'objective-c', 'java', 'javascript', 'typescript'];
+const LANGUAGES: string[] = ['cpp', 'c', 'objective-c', 'java', 'javascript', 'typescript', 'proto'];
 export const MODES: vscode.DocumentFilter[] = LANGUAGES.map(language => ({ language, scheme: 'file' }));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import cp = require('child_process');
 import path = require('path');
-import {C_MODE, CPP_MODE, OBJECTIVE_C_MODE, JAVA_MODE} from './clangMode';
+import {MODES} from './clangMode';
 import { getBinPath } from './clangPath';
 import sax = require('sax');
 
@@ -210,7 +210,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
     var formatter = new ClangDocumentFormattingEditProvider();
 
-    [C_MODE, CPP_MODE, JAVA_MODE, OBJECTIVE_C_MODE].forEach(mode => {
+    MODES.forEach(mode => {
         ctx.subscriptions.push(vscode.languages.registerDocumentRangeFormattingEditProvider(mode, formatter));
         ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(mode, formatter));
     })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,24 +120,27 @@ export class ClangDocumentFormattingEditProvider implements vscode.DocumentForma
         return this.defaultConfigure.executable;
     }
     
-    private getStyle() {
-        let ret = vscode.workspace.getConfiguration('clang-format').get<string>('style');
+    private getStyle(document: vscode.TextDocument) {
+        let ret = vscode.workspace.getConfiguration('clang-format').get<string>(`language.${document.languageId}.style`);
         if (ret.trim()) {
-            ret = ret.trim();
-        } else {
-            ret = this.defaultConfigure.style;
+            return ret.trim();
         }
-        
-        // Custom style
-        // if (ret.match(/[\\\{\" ]/)) {
-        //     return `"${ret.replace(/([\\\"])/g, "\\$1")}"`
-        // }
-        
-        return ret;
+
+        ret = vscode.workspace.getConfiguration('clang-format').get<string>('style');
+        if (ret && ret.trim()) {
+            return ret.trim();
+        } else {
+            return this.defaultConfigure.style;
+        }
     }  
     
-    private getFallbackStyle() {
-        let strConf = vscode.workspace.getConfiguration('clang-format').get<string>('fallbackStyle');
+    private getFallbackStyle(document: vscode.TextDocument) {
+        let strConf = vscode.workspace.getConfiguration('clang-format').get<string>(`language.${document.languageId}.fallbackStyle`);
+        if (strConf.trim()) {
+            return strConf;
+        }
+
+        strConf = vscode.workspace.getConfiguration('clang-format').get<string>('fallbackStyle');
         if (strConf.trim()) {
             return strConf;
         }
@@ -173,8 +176,8 @@ export class ClangDocumentFormattingEditProvider implements vscode.DocumentForma
 
             var formatArgs = [
                 '-output-replacements-xml',
-                `-style=${this.getStyle()}`,
-                `-fallback-style=${this.getFallbackStyle()}`,
+                `-style=${this.getStyle(document)}`,
+                `-fallback-style=${this.getFallbackStyle(document)}`,
                 `-assume-filename=${document.fileName}`,
             ];
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -171,9 +171,12 @@ export class ClangDocumentFormattingEditProvider implements vscode.DocumentForma
                 }
             };
 
-            var formatArgs = ['-output-replacements-xml'];
-            formatArgs.push(`-style=${this.getStyle()}`);
-            formatArgs.push(`-fallback-style=${this.getFallbackStyle()}`);
+            var formatArgs = [
+                '-output-replacements-xml',
+                `-style=${this.getStyle()}`,
+                `-fallback-style=${this.getFallbackStyle()}`,
+                `-assume-filename=${document.fileName}`,
+            ];
 
             if (range) {
                 var offset = document.offsetAt(range.start);


### PR DESCRIPTION
these code has merged PR[#14](https://github.com/xaverh/vscode-clang-format-provider/pull/14) and add some more functions. That's
- add protobuf support(work with https://marketplace.visualstudio.com/items?itemName=peterj.proto)
- allow different style & fallback style option for different languages
- format on save is available now(just like https://github.com/Microsoft/vscode-go/blob/master/src/goMain.ts)

@ioachim , I have tested in my vscode, but please review the code because there are many changes.
